### PR TITLE
feat: Add force close modal function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,38 @@
-# Open Source Project Template
+# MessageDialogService
 
-This repository contains a template to seed a repository for an Open Source
-project.
-
-## How to use this template
-
-1. Check out this repository
-2. Delete the `.git` folder
-3. Git init this repository and start working on your project!
-4. Prior to submitting your request for publication, make sure to review the
-   [Open Source guidelines for publications](https://nventive.visualstudio.com/Internal/_wiki/wikis/Internal_wiki?wikiVersion=GBwikiMaster&pagePath=%2FOpen%20Source%2FPublishing&pageId=7120).
-
-## Features (to keep as-is, configure or remove)
-- [Mergify](https://mergify.io/) is configured. You can edit or remove [.mergify.yml](/.mergify.yml).
 - [allcontributors](https://allcontributors.org/) is configured. It helps adding contributors to the README.
-- [dependabot](https://dependabot.com/) is configured. This bot will open pull requests automatically to update nuget dependencies. This one could be annoying, feel free to remove the [.dependabot](/.dependabot) folder.
 
-The following is the template for the final README.md file:
-
----
-
-# Project Title
-
-{Project tag line}
-
-{Small description of the purpose of the project}
+Show native prompt with custom content and title.
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
 ## Getting Started
 
-{Instructions to quickly get started using the project: pre-requisites, packages
-to install, sample code, etc.}
+Install the latest version of `MessageDialogService.Uno` in your project.
+
+There are 2 classes available that implement `IMessageDialogService`:
+
+- `AcceptOrDefaultMessageDialogService`
+  - Does not have a reference to Uno.
+  - [Reference](https://github.com/nventive/MessageDialogService/blob/master/src/MessageDialog/AcceptOrDefaultMessageDialogService.cs)
+- `MessageDialogService`
+  - Has a reference to Uno.
+  - [Reference](https://github.com/nventive/MessageDialogService/blob/master/src/MessageDialog.Uno/MessageDialogService.cs)
 
 ## Features
 
-{More details/listing of features of the project}
+### 1. Show Modal
+
+TODO: Explain builder and how to add content and title.
+
+### 2. Force Close Modal
+It is possible to manually close the current modal with:
+
+```csharp
+messageDialogService.ForceCloseModal();
+```
+
+This function is not async, therefore does not need to be awaited. This function will cancel the CancellationToken used by the modal. This will throw a System.OperationCanceledException.
 
 ## Changelog
 

--- a/src/MessageDialog.Uno/MessageDialog.Uno.csproj
+++ b/src/MessageDialog.Uno/MessageDialog.Uno.csproj
@@ -19,6 +19,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+	<!-- Can be removed when Uno.UI will be updated -->
+    <PackageReference Include="Uno.SourceGenerationTasks" Version="3.2.0" />
     <PackageReference Include="Uno.UI" Version="3.0.12" />
   </ItemGroup>
 

--- a/src/MessageDialog.Uno/MessageDialogService.cs
+++ b/src/MessageDialog.Uno/MessageDialogService.cs
@@ -15,6 +15,7 @@ namespace MessageDialogService
 	{
 		private readonly Func<CoreDispatcher> _dispatcher;
 		private readonly IMessageDialogBuilderDelegate _messageDialogServiceDelegate;
+		private CancellationTokenSource _ctSourceCurrentDialog;
 
 		public MessageDialogService(
 			Func<CoreDispatcher> dispatcher,
@@ -25,8 +26,13 @@ namespace MessageDialogService
 			_messageDialogServiceDelegate = messageDialogServiceDelegate;
 		}
 
-		/// <inheritdoc />
-		public Task<MessageDialogResult> ShowMessage(
+        public void ForceCloseDialog()
+        {
+			_ctSourceCurrentDialog.Cancel();
+		}
+
+        /// <inheritdoc />
+        public Task<MessageDialogResult> ShowMessage(
 			CancellationToken ct, 
 			Func<IMessageDialogBuilder<MessageDialogResult>, IMessageDialogBuilder<MessageDialogResult>> messageBuilder, 
 			MessageDialogResult defaultResult = MessageDialogResult.Cancel
@@ -76,6 +82,8 @@ namespace MessageDialogService
 			Func<IMessageDialogBuilder<TResult>, IMessageDialogBuilder<TResult>> messageBuilder,
 			TResult defaultResult = default(TResult))
 		{
+			_ctSourceCurrentDialog = CancellationTokenSource.CreateLinkedTokenSource(ct);
+
 			var innerBuilder = new MessageDialogBuilder<TResult>(_messageDialogServiceDelegate);
 			var builder = messageBuilder(innerBuilder);
 

--- a/src/MessageDialog/AcceptOrDefaultMessageDialogService.cs
+++ b/src/MessageDialog/AcceptOrDefaultMessageDialogService.cs
@@ -13,6 +13,13 @@ namespace MessageDialogService
 	/// </summary>
 	public class AcceptOrDefaultMessageDialogService: IMessageDialogService
 	{
+		private CancellationTokenSource _ctSourceCurrentDialog;
+
+		public void ForceCloseDialog()
+		{
+			_ctSourceCurrentDialog.Cancel();
+		}
+
 		public Task<TResult> ShowMessage<TResult>(
 			CancellationToken ct,
 			Func<IMessageDialogBuilder<TResult>, IMessageDialogBuilder<TResult>> messageBuilder,
@@ -24,6 +31,7 @@ namespace MessageDialogService
 				throw new ArgumentNullException(nameof(messageBuilder));
 			}
 
+			_ctSourceCurrentDialog = CancellationTokenSource.CreateLinkedTokenSource(ct);
 			var result = AcceptOrDefault(messageBuilder, defaultResult);
 
 			return Task.FromResult(result);
@@ -40,6 +48,7 @@ namespace MessageDialogService
 				throw new ArgumentNullException(nameof(messageBuilder));
 			}
 
+			_ctSourceCurrentDialog = CancellationTokenSource.CreateLinkedTokenSource(ct);
 			var result = AcceptOrDefault(messageBuilder, defaultResult);
 
 			return Task.FromResult(result);

--- a/src/MessageDialog/IMessageDialogService.cs
+++ b/src/MessageDialog/IMessageDialogService.cs
@@ -36,5 +36,12 @@ namespace MessageDialogService
 			CancellationToken ct,
 			Func<IMessageDialogBuilder<MessageDialogResult>, IMessageDialogBuilder<MessageDialogResult>> messageBuilder,
 			MessageDialogResult defaultResult = MessageDialogResult.Cancel);
+
+		/// <summary>
+		/// It will force close the active prompt by cancelling it.
+		/// Calling this method will throw a System.OperationCanceledException where a prompt was showed.
+		/// </summary>
+		void ForceCloseDialog();
+
 	}
 }


### PR DESCRIPTION


## Proposed Changes
Feature 

## What is the current behavior?
we cannot force close a prompt. (we had an issue where an undismissed prompt was still showing after the user was kicked out because of the auth token expiration)


## What is the new behavior?
It is now possible to force close a modal.


## Checklist

- [x] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue


## Other information

