### PR TITLE
feat: Support Android 12 and build on VS2022

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+* Build with VS2022
+* Add support for uap10.0.19041
+* Add support for Android 12
 * Support for Android 11 (March, 2021)
 * [#34] Change target Uno.UI version to 4.0.7
 
@@ -15,6 +18,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Deprecated
 
 ### Removed
+* Dropped support for uap10.0.18362
+* Dropped support for MonoAndroid10 target
 
 ### Fixed
 

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -11,7 +11,7 @@ resources:
 
 variables:
 - name: NUGET_VERSION
-  value: 5.8.1
+  value: 6.1.0
 - name: VSTEST_PLATFORM_VERSION
   value: 17.1.0
 - name: ArtifactName

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -7,13 +7,13 @@ trigger:
 resources:
    containers:
      - container: windows
-       image: nventive/vs_build-tools:16.8.6
+       image: nventive/vs_build-tools:17.1.1
 
 variables:
 - name: NUGET_VERSION
   value: 5.8.1
 - name: VSTEST_PLATFORM_VERSION
-  value: 16.8.6
+  value: 17.1.0
 - name: ArtifactName
   value: Packages
 - name: SolutionFileName # Example: MyApplication.sln
@@ -22,7 +22,7 @@ variables:
   value: $[or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/heads/feature/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'))]
 # Pool names
 - name: windowsPoolName
-  value: 'windows 1809'
+  value: 'windows 2022'
 
 stages:
 - stage: Build

--- a/build/gitversion.yml
+++ b/build/gitversion.yml
@@ -1,6 +1,6 @@
 assembly-versioning-scheme: MajorMinorPatch
 mode: ContinuousDeployment
-next-version: 0.4.0
+next-version: 0.5.0
 continuous-delivery-fallback-tag: ""
 increment: none # Disabled as it is not used. Saves time on the GitVersion step
 branches:

--- a/src/MessageDialog.Tests/MessageDialog.Tests.csproj
+++ b/src/MessageDialog.Tests/MessageDialog.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <IsPackable>false</IsPackable>
 		<AssemblyName>MessageDialogService.Tests</AssemblyName>
     <RootNamespace>MessageDialogService.Tests</RootNamespace>

--- a/src/MessageDialog.Uno/MessageDialog.Uno.csproj
+++ b/src/MessageDialog.Uno/MessageDialog.Uno.csproj
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<!-- Change the TargetFrameworks depending on which platform you are building on. This avoids errors as it is impossible to build UAP on OSX (MacOS) -->
 		<TargetFrameworks Condition="'$([MSBuild]::IsOsPlatform(OSX))'">netstandard2.0;xamarinios10;</TargetFrameworks>
-		<TargetFrameworks Condition="'!$([MSBuild]::IsOsPlatform(OSX))'">netstandard2.0;xamarinios10;monoandroid10.0;monoandroid11.0;uap10.0.18362</TargetFrameworks>
+		<TargetFrameworks Condition="'!$([MSBuild]::IsOsPlatform(OSX))'">netstandard2.0;xamarinios10;monoandroid11.0;monoandroid12.0;uap10.0.19041</TargetFrameworks>
 		<!-- Ensures the .xr.xml files are generated in a proper layout folder -->
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
 		<RootNamespace>MessageDialogService</RootNamespace>


### PR DESCRIPTION
GitHub Issue: #N/A

## Proposed Changes
Support Android 12 and build on VS2022

Feature
Build or CI related changes
Documentation content changes


## What is the current behavior?
Does not support Android 12 and build on VS2022


## What is the new behavior?
Supports Android 12 and build on VS2022


## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Contains **NO** breaking changes
- [x] Updated the Changelog
- [ ] Associated with an issue

Since all new projects will need to target Android 12, it is not needed to target Android 10 anymore


## Other information
