### PR TITLE
fix: add ID to Uno.WinUI head for nuget release

### DIFF
--- a/src/MessageDialog.Uno.WinUI/MessageDialog.Uno.WinUI.csproj
+++ b/src/MessageDialog.Uno.WinUI/MessageDialog.Uno.WinUI.csproj
@@ -6,6 +6,13 @@
 		<LangVersion>10.0</LangVersion>
 		<!-- Ensures the .xr.xml files are generated in a proper layout folder -->
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
+		<RootNamespace>MessageDialogService</RootNamespace>
+		<Authors>nventive</Authors>
+		<Company>nventive</Company>
+		<AssemblyName>MessageDialogService.Uno.WinUI</AssemblyName>
+		<PackageId>MessageDialogService.Uno.WinUI</PackageId>
+		<Description>MessageDialogService.Uno.WinUI</Description>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<DefineConstants>$(DefineConstants);WINUI</DefineConstants>
 	</PropertyGroup>
 	<ItemGroup>


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->
Adding AssemblyName and PackageId to the WinUI head.
<!-- - Bug fix -->
<!-- - Build or CI related changes -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->
Issue when using the Assembly name. The nuget package was published with an [incorrect name.](https://www.nuget.org/packages/MessageDialog.Uno.WinUI/0.5.0-feature.update-dotnet6.28) We need to unlist the incorrect package.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->
Should be finding the AssemblyName and ID correctly.

## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

